### PR TITLE
fix 1 added two modes aircraft and sentry OCR mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 # Use standard c++20
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Add DEBUG/RELEASE marco to define if debug/release configured
@@ -103,6 +103,8 @@ target_link_libraries(wv-basic-buff
 )
 list(APPEND WV_EXTRA_LIBS wv-basic-buff)
 
+
+
 list(APPEND EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/module/filter)
 add_library(wv-basic-kalman SHARED module/filter/basic_kalman.cpp)
 list(APPEND WV_EXTRA_LIBS wv-basic-kalman)
@@ -150,8 +152,11 @@ set(LIBRARY_OUTPUT_PATH "${PROJECT_BINARY_DIR}/lib")
 
 # Set configs folder absolute path
 set(CONFIG_FILE_PATH ${PROJECT_SOURCE_DIR}/configs)
+set(SOURCE_PATH ${PROJECT_SOURCE_DIR})
 target_compile_definitions(WolfVision PRIVATE "CONFIG_FILE_PATH=\"${CONFIG_FILE_PATH}\"")
+target_compile_definitions(WolfVision PRIVATE "SOURCE_PATH=\"${SOURCE_PATH}\"")
 target_compile_definitions(wv-basic-buff PRIVATE "CONFIG_FILE_PATH=\"${CONFIG_FILE_PATH}\"")
+target_compile_definitions(wv-onnx-inferring PRIVATE "CONFIG_FILE_PATH=\"${CONFIG_FILE_PATH}\"")
 
 # Add test_camera directory
 if(BUILD_TEST)

--- a/base/wolfvision.cpp
+++ b/base/wolfvision.cpp
@@ -7,24 +7,29 @@ int main() {
   cv::Mat src_img_;
 
   mindvision::VideoCapture mv_capture_ = mindvision::VideoCapture(
-    mindvision::CameraParam(0, mindvision::RESOLUTION_1280_X_800, mindvision::EXPOSURE_600));
+                                      mindvision::CameraParam(0, mindvision::RESOLUTION_1280_X_800, mindvision::EXPOSURE_600));
 
-  uart::SerialPort serial_ =
+  uart::SerialPort serial_ = 
     uart::SerialPort(fmt::format("{}{}", CONFIG_FILE_PATH, "/serial/uart_serial_config.xml"));
 
   cv::VideoCapture cap_ = cv::VideoCapture(0);
 
   basic_armor::Detector basic_armor_ = basic_armor::Detector(
-      fmt::format("{}{}", CONFIG_FILE_PATH, "/armor/basic_armor_config.xml"));
+    fmt::format("{}{}", CONFIG_FILE_PATH, "/armor/basic_armor_config.xml"));
 
   basic_buff::Detector basic_buff_ = basic_buff::Detector(
-      fmt::format("{}{}", CONFIG_FILE_PATH, "/buff/basic_buff_config.xml"));
+    fmt::format("{}{}", CONFIG_FILE_PATH, "/buff/basic_buff_config.xml"));
 
-  basic_pnp::PnP pnp_ = basic_pnp::PnP(
-      fmt::format("{}{}", CONFIG_FILE_PATH, "/camera/mv_camera_config_554.xml"),
-      fmt::format("{}{}", CONFIG_FILE_PATH, "/angle_solve/basic_pnp_config.xml"));
+  basic_pnp::PnP pnp_   = basic_pnp::PnP(
+    fmt::format("{}{}", CONFIG_FILE_PATH, "/camera/mv_camera_config_554.xml"), 
+    fmt::format("{}{}", CONFIG_FILE_PATH, "/angle_solve/basic_pnp_config.xml"));
 
-  fps::FPS global_fps_;
+  onnx_inferring::model model_ = 
+    onnx_inferring::model("/home/sms/workspace_vscode/WolfVision/module/ml/mnist-8.onnx");
+
+  //  onnx_inferring::model model_ = onnx_inferring::model(fmt::format("{}{}", CONFIG_FILE_PATH, "/ml/mnist-8.onnxl"));
+  basic_roi::RoI save_roi;
+  fps::FPS       global_fps_;
 
   while (true) {
     global_fps_.getTick();
@@ -40,57 +45,80 @@ int main() {
       switch (serial_.returnReceiveMode()) {
       case uart::SUP_SHOOT:
         if (basic_armor_.runBasicArmor(src_img_, serial_.returnReceive())) {
-          pnp_.solvePnP(serial_.returnReceiveBulletVelocity(),
-                        basic_armor_.returnFinalArmorDistinguish(0),
-                        basic_armor_.returnFinalArmorRotatedRect(0));
+          pnp_.solvePnP(serial_.returnReceiveBulletVelocity(), 
+                              basic_armor_.returnFinalArmorDistinguish(0), basic_armor_.returnFinalArmorRotatedRect(0));
         }
 
-        serial_.updataWriteData(pnp_.returnYawAngle(),
-                                pnp_.returnPitchAngle(),
-                                pnp_.returnDepth(),
-                                basic_armor_.returnArmorNum(),
-                                0);
+        serial_.updataWriteData(pnp_.returnYawAngle(), pnp_.
+                                returnPitchAngle(), pnp_.returnDepth(), basic_armor_.returnArmorNum(), 0);
         break;
       case uart::ENERGY_AGENCY:
         serial_.writeData(basic_buff_.runTask(src_img_, serial_.returnReceive()));
         break;
       case uart::SENTRY_MODE:
         if (basic_armor_.runBasicArmor(src_img_, serial_.returnReceive())) {
-          pnp_.solvePnP(serial_.returnReceiveBulletVelocity(),
-                        basic_armor_.returnFinalArmorDistinguish(0),
-                        basic_armor_.returnFinalArmorRotatedRect(0));
-          serial_.updataWriteData(pnp_.returnYawAngle(),
-                                  pnp_.returnPitchAngle(),
-                                  pnp_.returnDepth(),
-                                  basic_armor_.returnArmorNum(),
-                                  0);
+          pnp_.solvePnP(serial_.returnReceiveBulletVelocity(), 
+                              basic_armor_.returnFinalArmorDistinguish(0), basic_armor_.returnFinalArmorRotatedRect(0));
+          serial_.updataWriteData(pnp_.returnYawAngle(), 
+                                          pnp_.returnPitchAngle(), pnp_.returnDepth(), basic_armor_.returnArmorNum(), 0);
         } else {
           serial_.updataWriteData(pnp_.returnYawAngle(),
-                                  pnp_.returnPitchAngle(),
-                                  pnp_.returnDepth(),
-                                  basic_armor_.returnLostCnt() > 0 ? 1 : 0,
-                                  0);
+                                         pnp_.returnPitchAngle(), pnp_.returnDepth(), basic_armor_.returnLostCnt() > 0 ? 1 : 0, 0);
         }
         break;
       case uart::BASE_MODE:
         break;
       case uart::TOP_MODE:
         if (basic_armor_.runBasicArmor(src_img_, serial_.returnReceive())) {
-          pnp_.solvePnP(serial_.returnReceiveBulletVelocity(),
-                        basic_armor_.returnFinalArmorDistinguish(0),
-                        basic_armor_.returnFinalArmorRotatedRect(0));
-          serial_.updataWriteData(pnp_.returnYawAngle(),
-                                  pnp_.returnPitchAngle(),
-                                  pnp_.returnDepth(),
-                                  basic_armor_.returnArmorNum(),
-                                  0);
+          pnp_.solvePnP(serial_.returnReceiveBulletVelocity(), 
+                          basic_armor_.returnFinalArmorDistinguish(0), basic_armor_.returnFinalArmorRotatedRect(0));
+          serial_.updataWriteData(pnp_.returnYawAngle(), 
+                                        pnp_.returnPitchAngle(), pnp_.returnDepth(), basic_armor_.returnArmorNum(), 0);
         } else {
-          serial_.updataWriteData(-pnp_.returnYawAngle(),
-                                  pnp_.returnPitchAngle(),
-                                  pnp_.returnDepth(),
-                                  basic_armor_.returnLostCnt() > 0 ? 1 : 0,
-                                  0);
+          serial_.updataWriteData(-pnp_.returnYawAngle(), 
+                                       pnp_.returnPitchAngle(), pnp_.returnDepth(), basic_armor_.returnLostCnt() > 0 ? 1 : 0, 0);
         }
+      case uart::PLANE_MODE:
+        break;
+      case uart::OCR_SENTRYSELF_MODE:
+        if (basic_armor_.runBasicArmor(src_img_, serial_.returnReceive())) {
+          if (basic_armor_.returnFinalArmorDistinguish(0) == 1){  // if the firt type of the amror_list is large
+            pnp_.solvePnP(serial_.returnReceiveBulletVelocity(), 
+                                       basic_armor_.returnFinalArmorDistinguish(0), basic_armor_.returnFinalArmorRotatedRect(0));
+            serial_.updataWriteData(pnp_.returnYawAngle(),
+                                       pnp_.returnPitchAngle(), pnp_.returnDepth(), basic_armor_.returnArmorNum(), 0);
+          } else {  //another type
+            int info_number;
+            for (int i = 0; i < basic_armor_.returnArmorNum(); i++) {
+              info_number = model_.inferring(save_roi.cutRoIRotatedRect(basic_armor_.ReturnFrame(), 
+                                                                            basic_armor_.returnFinalArmorRotatedRect(i)));
+              if (info_number == 2) {
+                serial_.updataWriteData(pnp_.returnYawAngle(), 
+                                                pnp_.returnPitchAngle(), pnp_.returnDepth(), 0, 0);
+                break;
+              } else {
+                pnp_.solvePnP(serial_.returnReceiveBulletVelocity(), 
+                                       basic_armor_.returnFinalArmorDistinguish(i + 1), basic_armor_.returnFinalArmorRotatedRect(i + 1));
+                serial_.updataWriteData(pnp_.returnYawAngle(), 
+                                                pnp_.returnPitchAngle(), pnp_.returnDepth(), basic_armor_.returnArmorNum(), 0);
+                break;
+              }
+            }
+            if (model_.param_ocr.switch_number == 1) {
+              cv::imshow("Dafult", save_roi.cutRoIRotatedRect(basic_armor_.ReturnFrame(), 
+                                                                      basic_armor_.returnFinalArmorRotatedRect(0)));
+              cv::putText(basic_armor_.ReturnFrame(), std::to_string(info_number), cv::Point(100, 100), cv::FONT_HERSHEY_DUPLEX, 2, cv::Scalar(255, 255, 255), 2, cv::LINE_AA);
+            }
+          }
+        }
+        // serial_.updataWriteData(pnp_.returnYawAngle(),
+        //                         pnp_.returnPitchAngle(),
+        //                         pnp_.returnDepth(),
+        //                         basic_armor_.returnArmorNum(),
+        //                         0);
+        cv::putText(basic_armor_.ReturnFrame(), to_string(basic_armor_.returnArmorNum()), cv::Point(100, 200), cv::FONT_HERSHEY_DUPLEX, 2, cv::Scalar(255, 255, 255), 2, cv::LINE_AA);
+        cv::putText(basic_armor_.ReturnFrame(), to_string(serial_.returnReceiceColor()), cv::Point(100, 150), cv::FONT_HERSHEY_DUPLEX, 2, cv::Scalar(255, 255, 255), 2, cv::LINE_AA);
+        cv::imshow("frame", basic_armor_.ReturnFrame());
         break;
       default:
         break;
@@ -98,7 +126,7 @@ int main() {
       mv_capture_.cameraReleasebuff();
       basic_armor_.freeMemory();
       if (cv::waitKey(1) == 'q') {
-        return 0;
+        break;
       }
       global_fps_.calculateFPSGlobal();
     }

--- a/base/wolfvision.hpp
+++ b/base/wolfvision.hpp
@@ -9,5 +9,7 @@
 #include "devices/serial/uart_serial.hpp"
 #include "module/armor/basic_armor.hpp"
 #include "module/buff/basic_buff.hpp"
+#include "module/ml/onnx_inferring.hpp"
+
 
 auto idntifier = fmt::format(fg(fmt::color::green) | fmt::emphasis::bold, "wolfvision");

--- a/configs/ml/onnx_inferring_config.xml
+++ b/configs/ml/onnx_inferring_config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<opencv_storage>
+
+<!--
+/**
+ * @brief: 数字识别参数
+ */
+-->
+<H_MIN_NUM>3</H_MIN_NUM>
+<H_MAX_NUM>255</H_MAX_NUM>
+<S_MIN_NUM>6</S_MIN_NUM>
+<S_MAX_NUM>255</S_MAX_NUM>
+<V_MIN_NUM>2</V_MIN_NUM>
+<V_MAX_NUM>255</V_MAX_NUM>
+
+<CONFIDENT>666</CONFIDENT>
+<KERNEL_SIZE>2</KERNEL_SIZE>
+
+<!--
+    识别显示开关
+-->
+<NUMBER_SWITCH>1</NUMBER_SWITCH>
+
+</opencv_storage>

--- a/devices/serial/uart_serial.cpp
+++ b/devices/serial/uart_serial.cpp
@@ -279,8 +279,14 @@ void SerialPort::updateReceiveInformation() {
     case TOP_MODE:
       receive_data_.now_run_mode = TOP_MODE;
       break;
+      case PLANE_MODE:
+      receive_data_.now_run_mode = PLANE_MODE;
+      break;
+      case OCR_SENTRYSELF_MODE:
+      receive_data_.now_run_mode = OCR_SENTRYSELF_MODE;
+      break;
     default:
-      receive_data_.now_run_mode = SUP_SHOOT;
+      receive_data_.now_run_mode = OCR_SENTRYSELF_MODE;
       break;
   }
 

--- a/devices/serial/uart_serial.cpp
+++ b/devices/serial/uart_serial.cpp
@@ -259,7 +259,7 @@ void SerialPort::updateReceiveInformation() {
       receive_data_.my_color = BLUE;
       break;
     default:
-      receive_data_.my_color = RED;
+      receive_data_.my_color = ALL;
       break;
   }
 
@@ -286,7 +286,7 @@ void SerialPort::updateReceiveInformation() {
       receive_data_.now_run_mode = OCR_SENTRYSELF_MODE;
       break;
     default:
-      receive_data_.now_run_mode = OCR_SENTRYSELF_MODE;
+      receive_data_.now_run_mode = SUP_SHOOT;
       break;
   }
 

--- a/devices/serial/uart_serial.hpp
+++ b/devices/serial/uart_serial.hpp
@@ -47,6 +47,8 @@ enum RunMode {
   SENTRY_MODE,
   BASE_MODE,
   TOP_MODE,
+  PLANE_MODE,
+  OCR_SENTRYSELF_MODE,
 };
 
 // Describe the current robot ID information
@@ -67,7 +69,7 @@ struct Serial_Config {
 // Serial port information receiving structure
 struct Receive_Data {
   int   my_color;
-  int   now_run_mode;
+  int   now_run_mode = 7;
   int   my_robot_id;
   int   bullet_velocity;
   float acceleration;
@@ -85,8 +87,8 @@ struct Receive_Data {
   } Receive_Pitch_Angle_Info;
 
   Receive_Data() {
-    my_color                             = RED;
-    now_run_mode                         = SUP_SHOOT;
+    my_color                             = BLUE;
+    now_run_mode                         = OCR_SENTRYSELF_MODE;
     my_robot_id                          = INFANTRY;
     acceleration                         = 0.f;
     bullet_velocity                      = 30;

--- a/devices/serial/uart_serial.hpp
+++ b/devices/serial/uart_serial.hpp
@@ -69,7 +69,7 @@ struct Serial_Config {
 // Serial port information receiving structure
 struct Receive_Data {
   int   my_color;
-  int   now_run_mode = 7;
+  int   now_run_mode;
   int   my_robot_id;
   int   bullet_velocity;
   float acceleration;
@@ -88,7 +88,7 @@ struct Receive_Data {
 
   Receive_Data() {
     my_color                             = BLUE;
-    now_run_mode                         = OCR_SENTRYSELF_MODE;
+    now_run_mode                         = SUP_SHOOT;
     my_robot_id                          = INFANTRY;
     acceleration                         = 0.f;
     bullet_velocity                      = 30;

--- a/module/armor/basic_armor.cpp
+++ b/module/armor/basic_armor.cpp
@@ -160,9 +160,8 @@ bool Detector::findLight() {
 
 bool Detector::runBasicArmor(cv::Mat&           _src_img,
                              uart::Receive_Data _receive_data) {
-  frame = _src_img.clone();
   runImage(_src_img, _receive_data.my_color);
-  draw_img_ = _src_img;
+  draw_img_ = _src_img.clone();
 
   if (findLight()) {
     if (fittingArmor()) {

--- a/module/armor/basic_armor.cpp
+++ b/module/armor/basic_armor.cpp
@@ -160,6 +160,7 @@ bool Detector::findLight() {
 
 bool Detector::runBasicArmor(cv::Mat&           _src_img,
                              uart::Receive_Data _receive_data) {
+  frame = _src_img.clone();
   runImage(_src_img, _receive_data.my_color);
   draw_img_ = _src_img;
 
@@ -322,7 +323,7 @@ bool Detector::lightJudge(int i, int j) {
             armor_config_.armor_angle_different * 0.1) {
             cv::RotatedRect rects = cv::RotatedRect(
               (armor_data_.left_light.center + armor_data_.right_light.center) / 2,
-              cv::Size(armor_data_.width, armor_data_.height),
+              cv::Size(armor_data_.width , armor_data_.height),
               armor_data_.tan_angle);
 
           armor_data_.armor_rect      = rects;
@@ -358,14 +359,12 @@ int Detector::averageColor() {
   armor_data_.right_light_width  =
       MIN(armor_data_.right_light_height, armor_data_.right_light_width);
 
-  cv::RotatedRect rects = cv::RotatedRect(
-      (armor_data_.left_light.center + armor_data_.right_light.center) / 2,
-      cv::Size(
-        armor_data_.width - (armor_data_.left_light_width + armor_data_.right_light_width),
-        (armor_data_.left_light_height + armor_data_.right_light_height) / 2),
-      armor_data_.tan_angle);
-
-  cv::rectangle(draw_img_, rects.boundingRect(), cv::Scalar(0, 0, 255), 3, 8);
+  cv::RotatedRect rects =
+    cv::RotatedRect((armor_data_.left_light.center + armor_data_.right_light.center) / 2,
+                    cv::Size(armor_data_.width - (armor_data_.left_light_width + armor_data_.right_light_width),
+                    ((armor_data_.left_light_height + armor_data_.right_light_height) / 2)),
+                    armor_data_.tan_angle);
+  cv::rectangle(draw_img_ , rects.boundingRect(), cv::Scalar(255, 0, 0), 3, 8);
 
   armor_data_.armor_rect = rects;
   cv::Rect _rect         = rects.boundingRect();
@@ -528,17 +527,18 @@ cv::Mat Detector::hsvPretreat(cv::Mat&  _src_img,
       break;
     default:
       if (image_config_.color_edit) {
-        cv::createTrackbar("red_h_min:", window_name,
+        cv::namedWindow("hsv_trackbar");
+        cv::createTrackbar("red_h_min:", "hsv_trackbar",
                            &image_config_.h_red_min, 255, NULL);
-        cv::createTrackbar("red_h_max:", window_name,
+        cv::createTrackbar("red_h_max:", "hsv_trackbar",
                            &image_config_.h_red_max, 255, NULL);
-        cv::createTrackbar("red_s_min:", window_name,
+        cv::createTrackbar("red_s_min:", "hsv_trackbar",
                            &image_config_.s_red_min, 255, NULL);
-        cv::createTrackbar("red_s_max:", window_name,
+        cv::createTrackbar("red_s_max:", "hsv_trackbar",
                            &image_config_.s_red_max, 255, NULL);
-        cv::createTrackbar("red_v_min:", window_name,
+        cv::createTrackbar("red_v_min:", "hsv_trackbar",
                            &image_config_.v_red_min, 255, NULL);
-        cv::createTrackbar("red_v_max:", window_name,
+        cv::createTrackbar("red_v_max:", "hsv_trackbar",
                            &image_config_.v_red_max, 255, NULL);
         cv::imshow(window_name, hsv_trackbar_);
       }

--- a/module/armor/basic_armor.hpp
+++ b/module/armor/basic_armor.hpp
@@ -129,6 +129,7 @@ class Detector {
   cv::Mat grayPretreat(cv::Mat &_src_img, const int _my_color);
 
   cv::Mat fuseImage(cv::Mat _bin_gray_img, cv::Mat _bin_color_img);
+  cv::Mat ReturnFrame() {return frame;}
 
  private:
   Armor_Config armor_config_;

--- a/module/armor/basic_armor.hpp
+++ b/module/armor/basic_armor.hpp
@@ -129,7 +129,7 @@ class Detector {
   cv::Mat grayPretreat(cv::Mat &_src_img, const int _my_color);
 
   cv::Mat fuseImage(cv::Mat _bin_gray_img, cv::Mat _bin_color_img);
-  cv::Mat ReturnFrame() {return frame;}
+
 
  private:
   Armor_Config armor_config_;

--- a/module/ml/onnx_inferring.cpp
+++ b/module/ml/onnx_inferring.cpp
@@ -1,84 +1,20 @@
 #include "onnx_inferring.hpp"
+#include <string>
 
 namespace onnx_inferring {
 
-inline onnx_model::onnx_model(const char*     _onnx_model_path,
-                              const cv::Size& _input_size = cv::Size(28, 28)) {
-  load(_onnx_model_path);
-  layers();
+Number_Param::Number_Param(std::string path_input) {
+  cv::FileStorage model_ocr(path_input, cv::FileStorage::READ);
+  model_ocr["H_MIN_NUM"] >> h_min_num;
+  model_ocr["H_MAX_NUM"] >> h_max_num;
+  model_ocr["S_MIN_NUM"] >> s_min_num;
+  model_ocr["S_MAX_NUM"] >> s_max_num;
+  model_ocr["V_MIN_NUM"] >> v_min_num;
+  model_ocr["V_MAX_NUM"] >> v_max_num;
+  model_ocr["CONFIDENT"] >> Confident;
+  model_ocr["KERNEL_SIZE"] >> kennerl_size;
 
-  input_size_ = _input_size;
-}
-    
-inline int onnx_model::inferring(const cv::Mat& _input,
-                                 const int      _median_blur_kernel_size = 3,
-                                 const float    _probability_threshold   = 0) {
-  cv::resize(_input, tmp_, input_size_);
-  if (tmp_.channels() != 1) {
-      cv::cvtColor(tmp_, tmp_, cv::COLOR_BGR2GRAY);
-  }
-  if (_median_blur_kernel_size != 0) {
-      cv::medianBlur(tmp_, tmp_, _median_blur_kernel_size);
-  }
-  cv::threshold(tmp_, tmp_, 0, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
-
-  opencv_net_.setInput(cv::dnn::blobFromImage(tmp_));
-  
-  float max_probability     { 0 };
-  int   max_probability_idx { 0 };
-  int   i                   { -1 };
-
-  fmt::print("[{}] Info, inffering results:", idntifier_green);
-
-  opencv_net_.forward().forEach<float>(
-    [&_probability_threshold, &max_probability, &max_probability_idx, &i]
-    (float &data, [[maybe_unused]] const int * position) -> void {
-      if (++i) {
-          if (data > max_probability) {
-              max_probability     = data;
-              max_probability_idx = i;
-          }
-      } else {
-          if (data > _probability_threshold) {
-              max_probability = data;
-          } else {
-              max_probability = _probability_threshold;
-              max_probability_idx = -1;
-          }
-      }
-  
-      fmt::print(" {}", data);
-  });
-
-  fmt::print("\n");
-  
-  return max_probability_idx;
-}
-    
-
-inline void onnx_model::load(const char* _onnx_model_path) {
-  fmt::print("[{}] ONNX inferring using opencv: {}\n", idntifier_green, cv::getVersionString());
-    
-  model_path_ = _onnx_model_path;
-  opencv_net_ = cv::dnn::readNetFromONNX(model_path_);
-  
-  if (!opencv_net_.empty()) {
-    fmt::print("[{}] Load model success: {}\n", idntifier_green, model_path_);
-  } else {
-    fmt::print("[{}] Load model failed: {}\n", idntifier_red, model_path_);
-  }
-        
-#if __has_include(<opencv2/gpu/gpu.hpp>)
-  opencv_net_.setPreferableBackend(cv::dnn::DNN_TARGET_CUDA);
-#else
-  opencv_net_.setPreferableBackend(cv::dnn::DNN_TARGET_CPU);
-#endif
+  model_ocr["NUMBER_SWITCH"] >> switch_number;
 }
 
-inline void onnx_model::layers(void) {
-  if (opencv_net_.empty()) {
-    fmt::print("[{}] Error, phrasing model layers failed\n", idntifier_red);
-  }
-}
-
-}
+}  // namespace onnx_inferring

--- a/module/ml/onnx_inferring.hpp
+++ b/module/ml/onnx_inferring.hpp
@@ -51,11 +51,11 @@ class model {
 
     this->input_size = input_size;
   }
-  model();
+  model(){};
   // model(std::string orc_input_path_,bool key_input);
   NumParam param_ocr = Number_Param("/home/sms/workspace_vscode/WolfV_2/WolfVision/configs/ml/onnx_inferring_config.xml");
   bool     parma_case;
-  ~model();
+  ~model(){};
   /**
          @brief:  Inferring input image from loaded model, return classified int digit
          @param:  input, the image to classify (only 1 digit), const reference from cv::Mat

--- a/module/ml/onnx_inferring.hpp
+++ b/module/ml/onnx_inferring.hpp
@@ -21,9 +21,8 @@ using namespace std;
 
 namespace onnx_inferring {
 
-class Number_Param 
-{
-public:
+class Number_Param{
+ public:
   int h_min_num;
   int h_max_num;
 
@@ -38,16 +37,15 @@ public:
 
   int switch_number;
   explicit Number_Param(std::string path_in);
-} ;
-
-class model {
+};
+class model{
  public:
   /**
          @brief: Init model from params
          @param: onnx_model_path, the path of the modle on your machine, downloadable at https://github.com/onnx/models/blob/master/vision/classification/mnist/model/mnist-8.onnx
          @param: input_size, define the input layer size, default to cv::Size(28, 28)
          */
-  explicit model(std::string onnx_model_path, const cv::Size& input_size = cv::Size(28, 28)) {
+  inline explicit model(std::string onnx_model_path, const cv::Size& input_size = cv::Size(28, 28)) {
     model::load(onnx_model_path);
     model::layers();
 
@@ -55,9 +53,10 @@ class model {
   }
   model() {}
   // model(std::string orc_input_path_,bool key_input);
-  onnx_inferring::Number_Param param_ocr = onnx_inferring::Number_Param(fmt::format("{}{}", CONFIG_FILE_PATH, "/ml/onnx_inferring_config.xml"));
+  onnx_inferring::Number_Param param_ocr = onnx_inferring::Number_Param(
+                                                  fmt::format("{}{}", CONFIG_FILE_PATH, "/ml/onnx_inferring_config.xml"));
   bool parma_case;
-  ~model() {}
+  ~model() {Image_showput.release();}
   /**
          @brief:  Inferring input image from loaded model, return classified int digit
          @param:  input, the image to classify (only 1 digit), const reference from cv::Mat
@@ -69,9 +68,9 @@ class model {
          */
   /*/ inline int inferring(const cv::Mat& hsv_input, const int median_blur_kernel_size = 5, const cv::Scalar& hsv_lowerb = cv::Scalar(), 
                                                  const cv::Scalar& hsv_upperb = cv::Scalar(), const float probability_threshold = 0) */
-  inline int inferring(const cv::Mat& hsv_input, const int median_blur_kernel_size = 3, float probability_threshold = 0) {
+  inline int inferring(const cv::Mat& hsv_input, const int median_blur_kernel_size = 3, float probability_threshold = 0, cv::Mat Image_input = cv::Mat::zeros(cv::Size(255, 0), CV_8UC3)) {
     cv::resize(hsv_input, Image_output, input_size);
-
+    this->Image_showput = Image_input.clone();
     cv::namedWindow("数字number");
     cv::createTrackbar("h_min_num", "数字number", &param_ocr.h_min_num, 255, NULL);
     cv::createTrackbar("s_min_num", "数字number", &param_ocr.s_min_num, 255, NULL);
@@ -113,6 +112,10 @@ class model {
       }
     });
 
+    if (!Image_showput.empty()) {
+        cv::putText(Image_showput , to_string(max_probability_idx) , cv::Point(100 , 100) , cv::FONT_HERSHEY_DUPLEX ,  2, cv::Scalar(255 , 255 , 255) , 2 , cv::LINE_AA);
+        cv::imshow("number_img" , Image_showput);
+    }
     return max_probability_idx;
   }
 
@@ -161,6 +164,7 @@ class model {
 
   cv::Size input_size;
   cv::Mat  Image_output;
+  cv::Mat  Image_showput;
 };
 
 }  // namespace onnx_inferring

--- a/module/ml/onnx_inferring.hpp
+++ b/module/ml/onnx_inferring.hpp
@@ -21,7 +21,9 @@ using namespace std;
 
 namespace onnx_inferring {
 
-typedef struct Number_Param {
+class Number_Param 
+{
+public:
   int h_min_num;
   int h_max_num;
 
@@ -35,8 +37,8 @@ typedef struct Number_Param {
   int kennerl_size;
 
   int switch_number;
-  Number_Param(std::string path_in);
-} NumParam;
+  explicit Number_Param(std::string path_in);
+} ;
 
 class model {
  public:
@@ -51,11 +53,11 @@ class model {
 
     this->input_size = input_size;
   }
-  model(){};
+  model() {}
   // model(std::string orc_input_path_,bool key_input);
-  NumParam param_ocr = Number_Param("/home/sms/workspace_vscode/WolfV_2/WolfVision/configs/ml/onnx_inferring_config.xml");
-  bool     parma_case;
-  ~model(){};
+  onnx_inferring::Number_Param param_ocr = onnx_inferring::Number_Param(fmt::format("{}{}", CONFIG_FILE_PATH, "/ml/onnx_inferring_config.xml"));
+  bool parma_case;
+  ~model() {}
   /**
          @brief:  Inferring input image from loaded model, return classified int digit
          @param:  input, the image to classify (only 1 digit), const reference from cv::Mat

--- a/module/ml/onnx_inferring.hpp
+++ b/module/ml/onnx_inferring.hpp
@@ -1,37 +1,165 @@
+/*
+ * @name: opencv_onnx_inferring.hpp
+ * @namespace: ooi
+ * @class: model
+ * @brief: Load ONNX model and infer input image for classified int digit
+ * @author Unbinilium
+ * @version 1.0.1
+ * @date 2021-05-10
+ */
+
 #pragma once
 
-#include <fmt/core.h>
 #include <fmt/color.h>
+#include <fmt/core.h>
 
-#include <opencv2/core.hpp>
-#include <opencv2/imgproc.hpp>
-#include <opencv2/dnn.hpp>
+#include <string>
+#include <iostream>
+using namespace std;
+
+#include <opencv2/opencv.hpp>
 
 namespace onnx_inferring {
 
-auto idntifier_green = fmt::format(fg(fmt::color::green) | fmt::emphasis::bold, "onnx_inferring");
-auto idntifier_red   = fmt::format(fg(fmt::color::red)   | fmt::emphasis::bold, "onnx_inferring");
+typedef struct Number_Param {
+  int h_min_num;
+  int h_max_num;
 
-class onnx_model {
+  int s_min_num;
+  int s_max_num;
+
+  int v_min_num;
+  int v_max_num;
+
+  int Confident;
+  int kennerl_size;
+
+  int switch_number;
+  Number_Param(std::string path_in);
+} NumParam;
+
+class model {
  public:
-  inline onnx_model(const char*     _onnx_model_path,
-                    const cv::Size& _input_size);
-    
-  inline int inferring(const cv::Mat& _input,
-                       const int      _median_blur_kernel_size,
-                       const float    _probability_threshold);
-    
- protected:
-  inline void load(const char* _onnx_model_path);
+  /**
+         @brief: Init model from params
+         @param: onnx_model_path, the path of the modle on your machine, downloadable at https://github.com/onnx/models/blob/master/vision/classification/mnist/model/mnist-8.onnx
+         @param: input_size, define the input layer size, default to cv::Size(28, 28)
+         */
+  explicit model(std::string onnx_model_path, const cv::Size& input_size = cv::Size(28, 28)) {
+    model::load(onnx_model_path);
+    model::layers();
 
-  inline void layers(void);
-    
+    this->input_size = input_size;
+  }
+  model();
+  // model(std::string orc_input_path_,bool key_input);
+  NumParam param_ocr = Number_Param("/home/sms/workspace_vscode/WolfV_2/WolfVision/configs/ml/onnx_inferring_config.xml");
+  bool     parma_case;
+  ~model();
+  /**
+         @brief:  Inferring input image from loaded model, return classified int digit
+         @param:  input, the image to classify (only 1 digit), const reference from cv::Mat
+         @param:  median_blur_kernel_size, define the kernel size of median blur pre-processing, default to int 5, set 0 to disable
+         @param:  hsv_lowerb, the lower range for hsv image, pixels inside the range equals to 1, otherwise equals to 0, default is the cv::Scalar() default
+         @param:  hsv_upperb, the upper range for hsv image, pixels inside the range equals to 1, otherwise equals to 0, default is the cv::Scalar() default
+         @param:  probability_threshold, the min probability of considerable probability to iterate, determined by the model, mnist-8.onnx has the output array from -1e5 to 1e5, default is 0
+         @return: max_probability_idx, the most probable digit classified from input image in int type, -1 means all the probability is out of the threahold
+         */
+  /*/ inline int inferring(const cv::Mat& hsv_input, const int median_blur_kernel_size = 5, const cv::Scalar& hsv_lowerb = cv::Scalar(), 
+                                                 const cv::Scalar& hsv_upperb = cv::Scalar(), const float probability_threshold = 0) */
+  inline int inferring(const cv::Mat& hsv_input, const int median_blur_kernel_size = 3, float probability_threshold = 0) {
+    cv::resize(hsv_input, Image_output, input_size);
+
+    cv::namedWindow("数字number");
+    cv::createTrackbar("h_min_num", "数字number", &param_ocr.h_min_num, 255, NULL);
+    cv::createTrackbar("s_min_num", "数字number", &param_ocr.s_min_num, 255, NULL);
+    cv::createTrackbar("v_min_num", "数字number", &param_ocr.v_min_num, 255, NULL);
+    // 置信度
+    cv::createTrackbar("CONFIDENT", "数字number", &param_ocr.Confident, 5000, NULL);
+    cv::createTrackbar("kernel_size", "数字number", &param_ocr.kennerl_size, 10, NULL);
+    if (median_blur_kernel_size != 0) {
+      cv::medianBlur(Image_output, Image_output, param_ocr.kennerl_size * 2 - 1);
+    }
+    cv::inRange(Image_output, cv::Scalar(param_ocr.h_min_num, param_ocr.s_min_num, param_ocr.v_min_num), cv::Scalar(255, 255, 255), Image_output);
+
+    // cv::Mat element = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
+    // cv::morphologyEx(Image_output, Image_output, cv::MORPH_OPEN, element);
+    // cv::dilate(Image_output, Image_output, cv::Mat(cv::Size(3, 3), CV_8UC1));
+    // cv::bitwise_not(Image_output, Image_output);
+
+    cv::imshow("output_img_ocr", Image_output);
+
+    opencv_net.setInput(cv::dnn::blobFromImage(Image_output));
+
+    float max_probability{0};
+    int   max_probability_idx{0};
+    int   i{-1};
+    probability_threshold = param_ocr.Confident;
+    opencv_net.forward().forEach<float>([&probability_threshold, &max_probability, &max_probability_idx, &i](float& data, [[maybe_unused]] const int* position) -> void {
+      if (++i) {
+        if (data > max_probability) {
+          max_probability     = data;
+          max_probability_idx = i;
+        }
+      } else {
+        if (data > probability_threshold) {
+          max_probability = data;
+        } else {
+          max_probability     = probability_threshold;
+          max_probability_idx = -1;
+        }
+      }
+    });
+
+    return max_probability_idx;
+  }
+
+ protected:
+  /*
+         @brief: Load model from onnx_model_path
+         @param: onnx_model_path, the path of the modle on your machine, downloadable at https://github.com/onnx/models/blob/master/vision/classification/mnist/model/mnist-8.onnx
+         */
+  inline void load(std::string onnx_model_path) {
+    std::cout << "[OOI] opencv version: " << cv::getVersionString() << std::endl;
+
+    model_path = onnx_model_path;
+    opencv_net = cv::dnn::readNetFromONNX(model_path);
+
+    if (!opencv_net.empty()) {
+      std::cout << "[OOI] load model success: " << model_path << std::endl;
+    } else {
+      std::cout << "[OOI] load model failed: " << model_path << std::endl;
+      return;
+    }
+
+#if __has_include(<opencv2/gpu/gpu.hpp>)
+    opencv_net.setPreferableBackend(cv::dnn::DNN_TARGET_CUDA);
+#else
+    opencv_net.setPreferableBackend(cv::dnn::DNN_TARGET_CPU);
+#endif
+  }
+  /*
+         @brief: Print model layers detail from loaded model
+         */
+  inline void layers(void) {
+    if (opencv_net.empty()) {
+      std::cout << "[OOI] model is empty" << std::endl;
+      return;
+    }
+
+    std::cout << "[OOI] model from " << model_path << " has layers: " << std::endl;
+    for (const auto& layer_name : opencv_net.getLayerNames()) {
+      std::cout << "\t\t" << layer_name << std::endl;
+    }
+  }
+
  private:
-  cv::dnn::Net opencv_net_;
-  const char*  model_path_;
-  
-  cv::Size     input_size_;
-  cv::Mat      tmp_;
+  cv::dnn::Net opencv_net;
+  std::string  model_path;
+
+  cv::Size input_size;
+  cv::Mat  Image_output;
 };
 
-}
+}  // namespace onnx_inferring
+


### PR DESCRIPTION
fix:1 modified devices/ml/onnx_inmferring.cpp and onnx_inferring.hpp
fix: 2 Change the file of the model by configs/ml/onnx_inferring_config.xml
fix: 3 the armor file adds the copy and return of the original image, but we don't know that the image directly read by the 
          straight camera can't be added to the digital recognition. Thanks for a function to return the read original image


1 修改了输入的onnx_头文件和cpp文件
2 onnx\uuu推断\uuuu修改配置文件
3 armor文件添加了原始图像的拷贝和返回，但我们不知道读取相机直接读取的图像不能添加到数字识别中。提供了一个函数来返回读取的原始图像
4 wolfversioncpp要增加路径和修改串读取飞机和OCR哨兵模式中的内容接口即可



还存在的问题：无法添加相对路径