### PR TITLE
fix:Repair serial port without +-

### DIFF
--- a/configs/serial/uart_serial_config.xml
+++ b/configs/serial/uart_serial_config.xml
@@ -7,7 +7,7 @@
   - 1  B115200
   - 10 B921600
  -->
-<SET_BAUDRATE>1</SET_BAUDRATE>
+<SET_BAUDRATE>10</SET_BAUDRATE>
 <!-- 
   SHOW_SERIAL_INFORMATION - wheather print serial inforation
   - 0 Disable

--- a/devices/serial/uart_serial.cpp
+++ b/devices/serial/uart_serial.cpp
@@ -142,7 +142,14 @@ void SerialPort::writeData(const int&     _yaw,   const int16_t& yaw,
   }
 }
 
-void SerialPort::writeData(const Write_Data& _write_data) {
+void SerialPort::writeData(Write_Data& _write_data) {
+  _write_data.data_type = _write_data.data_type > 1 ? 1 : _write_data.data_type;
+  _write_data.is_shooting = _write_data.is_shooting;
+  _write_data.symbol_yaw = _write_data.yaw_angle >= 0 ? 1 : 0;
+  _write_data.yaw_angle = fabs(_write_data.yaw_angle) * 100;
+  _write_data.symbol_pitch = _write_data.pitch_angle >= 0 ? 1 : 0;
+  _write_data.pitch_angle = fabs(_write_data.pitch_angle) * 100;
+  _write_data.depth = _write_data.depth;
   writeData(_write_data.symbol_yaw,   _write_data.yaw_angle,
             _write_data.symbol_pitch, _write_data.pitch_angle,
             _write_data.depth,        _write_data.data_type,
@@ -311,7 +318,7 @@ void SerialPort::updateReceiveInformation() {
       break;
   }
 
-  receive_data_.bullet_velocity = receive_buff_[14];
+  receive_data_.bullet_velocity = receive_buff_[14] - 2;
 
   for (size_t i = 0; i != sizeof(receive_data_.Receive_Yaw_Angle_Info.arr_yaw_angle); ++i) {
     receive_data_.Receive_Yaw_Angle_Info.arr_yaw_angle[i] = receive_buff_[i + 4];

--- a/devices/serial/uart_serial.hpp
+++ b/devices/serial/uart_serial.hpp
@@ -165,7 +165,7 @@ class SerialPort {
                  const int16_t& depth,  const int&     data_type = 0,
                  const int&     s_shooting = 0);
   void writeData();
-  void writeData(const Write_Data& _write_data);
+  void writeData(Write_Data& _write_data);
 
   void updataWriteData(const float _yaw,   const float _pitch,
                        const int   _depth, const int   _data_type = 0,


### PR DESCRIPTION
1、修改serial config 文件 默认波特率
2、修复serial 接口没有正负判断的bug